### PR TITLE
feature/add-mariadb-mongo-express

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,34 @@ lint:
 ######################
 #   docker compose   #
 ######################
-compose:
-	docker build -t simple-dataops-docker-airflow -f docker/airflow/Dockerfile .
-	docker compose up -d
+all:
+	make database
+	make airflow
+	make broker
 
-compose-clean:
-	docker compose down -v
-	docker rmi simple-dataops-docker-data-generator simple-dataops-docker-airflow
+all-clean:
+	make broker-clean
+	make airflow-clean
+	make database-clean
+
+database:
+	docker compose -p database -f docker-compose-database.yaml up -d
+
+database-clean:
+	docker compose -p database down -v
+	docker rmi database-data-generator
+
+airflow:
+	docker build -t airflow -f docker/airflow/Dockerfile .
+	docker compose -p airflow -f docker-compose-airflow.yaml up -d
+
+airflow-clean:
+	docker compose -p airflow down -v
+	docker rmi airflow
 	rm -r ./logs
+
+broker:
+	docker compose -p broker -f docker-compose-broker.yaml up -d
+
+broker-clean:
+	docker compose -p broker down -v

--- a/docker-compose-airflow.yaml
+++ b/docker-compose-airflow.yaml
@@ -1,44 +1,6 @@
 version: "3"
 
 services:
-  data-generator:
-    build:
-      context: docker/data-generator
-      dockerfile: Dockerfile
-    container_name: data-generator
-    depends_on:
-      mongodb:
-        condition: service_healthy
-
-  mongodb:
-    image: mongo:6.0.6
-    container_name: mongodb
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: mongo
-      MONGO_INITDB_ROOT_PASSWORD: mongo
-    ports:
-      - 27017:27017
-    healthcheck:
-      test: ["CMD","mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  rabbitmq:
-    image: rabbitmq:3-management
-    container_name: rabbitmq
-    environment:
-      RABBITMQ_DEFAULT_USER: rabbit
-      RABBITMQ_DEFAULT_PASS: rabbit
-    ports:
-      - 5672:5672
-      - 15672:15672
-    healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   postgres:
     image: postgres:14.0
     container_name: postgres
@@ -66,7 +28,7 @@ services:
       retries: 5
 
   initdb:
-    image: simple-dataops-docker-airflow:latest
+    image: airflow:latest
     container_name: initdb
     depends_on:
       - redis
@@ -81,7 +43,7 @@ services:
         airflow users create --firstname admin --lastname admin --email admin --password admin --username admin --role Admin
 
   webserver:
-    image: simple-dataops-docker-airflow:latest
+    image: airflow:latest
     container_name: webserver
     depends_on:
       - initdb
@@ -92,7 +54,7 @@ services:
     command: webserver
 
   scheduler:
-    image: simple-dataops-docker-airflow:latest
+    image: airflow:latest
     container_name: scheduler
     depends_on:
       - webserver
@@ -104,7 +66,7 @@ services:
       - ./logs:/opt/airflow/logs
 
   flower:
-    image: simple-dataops-docker-airflow:latest
+    image: airflow:latest
     container_name: flower
     depends_on:
       - redis
@@ -115,7 +77,7 @@ services:
     command: celery flower
 
   worker1:
-    image: simple-dataops-docker-airflow:latest
+    image: airflow:latest
     container_name: worker1
     depends_on:
       - scheduler
@@ -127,7 +89,7 @@ services:
       - ./logs:/opt/airflow/logs
 
   worker2:
-    image: simple-dataops-docker-airflow:latest
+    image: airflow:latest
     container_name: worker2
     depends_on:
       - scheduler
@@ -139,7 +101,7 @@ services:
       - ./logs:/opt/airflow/logs
 
   worker3:
-    image: simple-dataops-docker-airflow:latest
+    image: airflow:latest
     container_name: worker3
     depends_on:
       - scheduler
@@ -149,3 +111,7 @@ services:
     volumes:
       - ./src/dags:/opt/airflow/dags
       - ./logs:/opt/airflow/logs
+
+networks:
+  default:
+    name: simple-dataops-network

--- a/docker-compose-broker.yaml
+++ b/docker-compose-broker.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: rabbit
+      RABBITMQ_DEFAULT_PASS: rabbit
+    ports:
+      - 5672:5672
+      - 15672:15672
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+networks:
+  default:
+    name: simple-dataops-network

--- a/docker-compose-database.yaml
+++ b/docker-compose-database.yaml
@@ -1,0 +1,60 @@
+version: "3"
+
+services:
+  mongodb:
+    image: mongo:6.0.6
+    container_name: mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: mongo
+      MONGO_INITDB_ROOT_PASSWORD: mongo
+    ports:
+      - 27017:27017
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mongo-express:
+    image: mongo-express:1.0.0-alpha
+    container_name: mongo-express
+    environment:
+      ME_CONFIG_MONGODB_SERVER: mongodb
+      ME_CONFIG_MONGODB_ADMINUSERNAME: mongo
+      ME_CONFIG_MONGODB_ADMINPASSWORD: mongo
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: admin
+    ports:
+      - 8081:8081
+    depends_on:
+      mongodb:
+        condition: service_healthy
+
+  data-generator:
+    build:
+      context: docker/data-generator
+      dockerfile: Dockerfile
+    container_name: data-generator
+    depends_on:
+      mongodb:
+        condition: service_healthy
+
+  mariadb:
+    image: mariadb:10.6.13
+    container_name: mariadb
+    environment:
+      MARIADB_USER: maria
+      MARIADB_PASSWORD: maria
+      MARIADB_DATABASE: maria
+      MARIADB_ROOT_PASSWORD: maria
+    ports:
+      - 3306:3306
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+networks:
+  default:
+    name: simple-dataops-network


### PR DESCRIPTION
## Changes?
<!-- 이 PR 로 인해서 무엇이 변경되었는지 작성해주세요 -->

- Compose 파일 분리
- Maria DB 추가
- Mongo DB의 UI 접근을 위한 mongo express 추가

## Test?
<!-- 어떻게 테스트했는지, 어떻게 reproduce 할 수 있는지 간단하게 작성해주세요 -->

```bash
$ make all
$
$ make all-clean
```

mongo express -> http://localhost:8081 접속

## Related Issues?
<!-- 관련된 이슈가 있다면 #xx 로 이슈 번호를 작성해주세요 -->

## Anything Else? (Optional)
<!-- 스크린샷, 환경 정보, 주의사항 등 필요한 추가정보가 있다면 작성해주세요. -->
![스크린샷 2023-05-31 오후 6 27 14](https://github.com/fearless-pioneer/simple-dataops-docker/assets/29733842/01ee75fc-9c11-454f-a431-6f387ee20b69)

![스크린샷 2023-05-31 오후 6 27 19](https://github.com/fearless-pioneer/simple-dataops-docker/assets/29733842/6cb295f2-4630-416d-83c0-2855cc7a885f)

![스크린샷 2023-05-31 오후 6 27 25](https://github.com/fearless-pioneer/simple-dataops-docker/assets/29733842/f8c89bf6-eb1a-49d0-91a2-06e6adc4aad9)